### PR TITLE
Fix links in README.md

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -547,8 +547,8 @@ webhooks:
 
 ## API specification
 
-- [Hanko Public API](https://docs.hanko.io/api/public)
-- [Hanko Admin API](https://docs.hanko.io/api/admin)
+- [Hanko Public API](https://docs.hanko.io/api-reference/public/introduction)
+- [Hanko Admin API](https://docs.hanko.io/api-reference/admin/introduction)
 
 ## Configuration reference
 


### PR DESCRIPTION
Fixing broken links to the API documentation in backend/README.md.

# Description

Trivial documentation update to fix a couple of broken links to the docs.hanko.io site. Doesn't touch anything else.